### PR TITLE
Add alternate path to scw-metadata

### DIFF
--- a/files/default/scaleway.rb
+++ b/files/default/scaleway.rb
@@ -3,7 +3,11 @@
 # Scaleway's boxes and collect the metadata there
 #
 
-scw_metadata = "/usr/local/bin/scw-metadata"
+scw_metadata = if File.executable?('/usr/local/bin/scw-metadata')
+                 '/usr/local/bin/scw-metadata'
+               else
+                 '/run/initramfs/usr/bin/scw-metadata'
+               end
 
 Ohai.plugin(:Scaleway) do
   provides 'scw'


### PR DESCRIPTION
Some flavors of Scaleway instances (Eg: VC1S) unmount the /run/initramfs/usr/bin which is overlayed onto /usr/bin after having been booted for a few minutes. This ensures scw-metadata is accessible in such cases.